### PR TITLE
Code Quality (some suggestions)

### DIFF
--- a/lib/googl.js
+++ b/lib/googl.js
@@ -32,9 +32,7 @@
             url = 'http://' + url;
         }
 
-        if (API_KEY && typeof API_KEY === 'string') {
-            options.qs.key = API_KEY;
-        }
+        options.qs.key = API_KEY;
 
         switch(type) {
             case 'shorten':
@@ -124,7 +122,6 @@
     }
 
     module.exports = {
-        _googleRequest: _googleRequest,
         shorten: shorten,
         expand: expand,
         setKey: setKey,


### PR DESCRIPTION
#### _googleRequest

I think this one is `private` method and shouldn't allow user to use this method.
#### options.qs.key = API_KEY

You have define init `API_KEY = '';` , and check type in method `setKey(key)`, so you don't have to check again in that section.
## 

_Just some suggestions for you =)_
