### PR TITLE
Add referer to extra options

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ googl.shorten('www.spotify.com', { quotaUser: 'UserID' })
         console.error(err.message);
     });
 
+// Shorten a goo.gl url and pass a referer to be used with referer restrictions.
+// See: https://support.google.com/googleapi/answer/6310037?hl=en
+googl.shorten('www.spotify.com', { referer: 'my.domain.com' })
+    .then(function (shortUrl) {
+        console.log(shortUrl);
+    })
+    .catch(function (err) {
+        console.error(err.message);
+    });
+
 // Look up a short URL's analytics
 // See: https://developers.google.com/url-shortener/v1/getting_started#url_analytics
 googl.analytics('http://goo.gl/fbsS', {projection: 'ANALYTICS_CLICKS'})

--- a/lib/googl.js
+++ b/lib/googl.js
@@ -58,10 +58,15 @@
         // @link https://developers.google.com/console/help/#cappingusage
         if (typeof extraOptions === 'object') {
             for (var opt in extraOptions) {
-                if (type === 'shorten') {
-                    options.body[opt] = extraOptions[opt];
-                } else if (type === 'expand' || type === 'analytics') {
-                    options.qs[opt] = extraOptions[opt];
+                // Add referer to the headers to be used with referer restrictions.
+                if (opt === 'referer') {
+                    options.headers = {referer: extraOptions[opt]};
+                } else {
+                    if (type === 'shorten') {
+                        options.body[opt] = extraOptions[opt];
+                    } else if (type === 'expand' || type === 'analytics') {
+                        options.qs[opt] = extraOptions[opt];
+                    }
                 }
             }
         }


### PR DESCRIPTION
This allows adding the referer to the extra options so that HTTP referrer restrictions can be used. See https://support.google.com/googleapi/answer/6310037?hl=en
